### PR TITLE
AutotoolsPackage with no autoreconf

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -56,10 +56,10 @@ class Octopus(AutotoolsPackage, CudaPackage):
     variant("nlopt", default=False, description="Compile with nlopt")
     variant("debug", default=False, description="Compile with debug flags")
 
-    depends_on("autoconf", type="build")
-    depends_on("automake", type="build")
-    depends_on("libtool", type="build")
-    depends_on("m4", type="build")
+    depends_on("autoconf", type="build", when="@develop")
+    depends_on("automake", type="build", when="@develop")
+    depends_on("libtool", type="build", when="@develop")
+    depends_on("m4", type="build", when="@develop")
 
     depends_on("blas")
     depends_on("gsl@1.9:")

--- a/spack/package.py
+++ b/spack/package.py
@@ -91,9 +91,6 @@ class Octopus(AutotoolsPackage, CudaPackage):
     # TODO: etsf-io, sparskit,
     # feast, libfm, pfft, isf, pnfft, poke
 
-    def autoreconf(self, spec, prefix):
-
-        autoreconf("--install", "--verbose", "--force")
 
     def configure_args(self):
         spec = self.spec
@@ -316,4 +313,3 @@ class Octopus(AutotoolsPackage, CudaPackage):
                 purpose=purpose,
                 skip_missing=False,
             )
-            

--- a/spack/package.py
+++ b/spack/package.py
@@ -10,7 +10,8 @@ import llnl.util.tty as tty
 from spack.package import *
 import llnl.util.filesystem as fs
 
-class Octopus(Package, CudaPackage):
+
+class Octopus(AutotoolsPackage, CudaPackage):
     """A real-space finite-difference (time-dependent) density-functional
     theory code."""
 
@@ -90,7 +91,12 @@ class Octopus(Package, CudaPackage):
     # TODO: etsf-io, sparskit,
     # feast, libfm, pfft, isf, pnfft, poke
 
-    def install(self, spec, prefix):
+    def autoreconf(self, spec, prefix):
+
+        autoreconf("--install", "--verbose", "--force")
+
+    def configure_args(self):
+        spec = self.spec
         lapack = spec["lapack"].libs
         blas = spec["blas"].libs
         args = []
@@ -211,12 +217,7 @@ class Octopus(Package, CudaPackage):
                 args.append(fcflags)
                 args.append(fflags)
 
-        autoreconf("-i")
-        configure(*args)
-        make()
-        # short tests take forever...
-        # make('check-short')
-        make("install")
+        return args
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
@@ -315,3 +316,4 @@ class Octopus(Package, CudaPackage):
                 purpose=purpose,
                 skip_missing=False,
             )
+            


### PR DESCRIPTION
Refactored to use AutotoolsPackage. Removed autoreconf method and added when="@develop" to the autoconf, automake, libtool and m4 dependencies 