### PR TITLE
install and test both versions via separate environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,9 +73,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack add octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
-      spack test run --alias testname octopus && \
+      spack test run --alias test_serial octopus && \
       # display output from smoke tests (just for information):
-      spack test results -l testname && \
+      spack test results -l test_serial && \
       # show which octopus version we use (for convenience):
       spack load octopus && octopus --version && \
       # deactivate the environment.
@@ -93,9 +93,9 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack add octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt +mpi && \
       spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
-      spack test run --alias testname octopus && \
+      spack test run --alias test_MPI octopus && \
       # display output from smoke tests (just for information):
-      spack test results -l testname && \
+      spack test results -l test_MPI && \
       # show which octopus version we use (for convenience):
       spack load octopus && octopus --version && \
       # deactivate the environment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       # display specs of upcoming spack installation:
       spack spec octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt && \
       # run the spack installation (adding it to the environment):
-      spack install --add octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt && \
+      spack add octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt && \
+      spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias testname octopus && \
       # display output from smoke tests (just for information):
@@ -89,7 +90,8 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       # display specs of upcoming spack installation:
       spack spec octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt +mpi && \
       # run the spack installation (adding it to the environment):
-      spack install --add octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt +mpi && \
+      spack add octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt +mpi && \
+      spack install && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias testname octopus && \
       # display output from smoke tests (just for information):

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,8 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env activate octopus-serial && \
       # display specs of upcoming spack installation:
       spack spec octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt && \
-      # run the spack installation:
-      spack install octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt && \
+      # run the spack installation (adding it to the environment):
+      spack install --add octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias testname octopus && \
       # display output from smoke tests (just for information):
@@ -88,8 +88,8 @@ RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
       spack env activate octopus-mpi && \
       # display specs of upcoming spack installation:
       spack spec octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt +mpi && \
-      # run the spack installation:
-      spack install octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt +mpi && \
+      # run the spack installation (adding it to the environment):
+      spack install --add octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt +mpi && \
       # run spack smoke tests for octopus. We get an error if any of the fails:
       spack test run --alias testname octopus && \
       # display output from smoke tests (just for information):

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,19 +60,44 @@ RUN ls -l $SPACK_ROOT/var/spack/repos/builtin/packages/octopus
 COPY spack/test/ $SPACK_ROOT/var/spack/repos/builtin/packages/octopus/test
 RUN ls -l $SPACK_ROOT/var/spack/repos/builtin/packages/octopus/test
 
-# display specs of upcoming spack installation
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack spec octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt
+# Install and test serial and MPI versions of ocoptus via spack
+# # serial version
 
-# run the spack installation
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack install octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt
+RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
+      # create a new environment for the serial version and activate it:
+      spack env create octopus-serial && \
+      spack env activate octopus-serial && \
+      # display specs of upcoming spack installation:
+      spack spec octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt && \
+      # run the spack installation:
+      spack install octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt && \
+      # run spack smoke tests for octopus. We get an error if any of the fails:
+      spack test run --alias testname octopus && \
+      # display output from smoke tests (just for information):
+      spack test results -l testname && \
+      # show which octopus version we use (for convenience):
+      spack load octopus && octopus --version && \
+      # deactivate the environment.
+      spack env deactivate
 
-# run spack smoke tests for octopus. We get an error if any of the fail.
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack test run --alias testname octopus
-# display output from smoke tests (just for information)
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack test results -l testname
+# # MPI version
 
-# # show which octopus version we use (for convenience)
-RUN . $SPACK_ROOT/share/spack/setup-env.sh && spack load octopus && octopus --version
+RUN . $SPACK_ROOT/share/spack/setup-env.sh && \
+      # create a new environment for the MPI version and activate it:
+      spack env create octopus-mpi && \
+      spack env activate octopus-mpi && \
+      # display specs of upcoming spack installation:
+      spack spec octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt +mpi && \
+      # run the spack installation:
+      spack install octopus@${OCT_VERSION} +netcdf+parmetis+arpack+cgal+pfft+python+likwid+libyaml+elpa+nlopt +mpi && \
+      # run spack smoke tests for octopus. We get an error if any of the fails:
+      spack test run --alias testname octopus && \
+      # display output from smoke tests (just for information):
+      spack test results -l testname && \
+      # show which octopus version we use (for convenience):
+      spack load octopus && octopus --version && \
+      # deactivate the environment.
+      spack env deactivate
 
 # Provide bash in case the image is meant to be used interactively
 CMD /bin/bash -l


### PR DESCRIPTION
Run installation and tests for both the serial and MPI variants via separate environments.